### PR TITLE
refactor/renaming-auth-and-moving-types

### DIFF
--- a/src/app/api/auth/[...auth]/route.ts
+++ b/src/app/api/auth/[...auth]/route.ts
@@ -1,5 +1,5 @@
 import { toNextJsHandler } from "better-auth/next-js";
 
-import { auth } from "@/lib/auth/auth";
+import { authServer } from "@/lib/auth/auth-server";
 
-export const { GET, POST } = toNextJsHandler(auth);
+export const { GET, POST } = toNextJsHandler(authServer);

--- a/src/app/api/monzo/accounts/route.ts
+++ b/src/app/api/monzo/accounts/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
 
-import { auth } from "@/lib/auth/auth";
+import { authServer } from "@/lib/auth/auth-server";
 import { db, monzoAccounts } from "@/lib/db";
 
 import { fetchAccounts } from "./endpoints";
@@ -9,7 +9,7 @@ import { getDatabaseAccount } from "./utils";
 
 export async function GET(request: Request): Promise<NextResponse> {
   try {
-    const session = await auth.api.getSession({
+    const session = await authServer.api.getSession({
       headers: request.headers,
     });
 
@@ -38,7 +38,7 @@ export async function GET(request: Request): Promise<NextResponse> {
 
 export async function POST(request: Request): Promise<NextResponse> {
   try {
-    const session = await auth.api.getSession({
+    const session = await authServer.api.getSession({
       headers: request.headers,
     });
 
@@ -49,7 +49,7 @@ export async function POST(request: Request): Promise<NextResponse> {
       );
     }
 
-    const { accessToken } = await auth.api.getAccessToken({
+    const { accessToken } = await authServer.api.getAccessToken({
       body: { providerId: "monzo", userId: session.user.id },
     });
 

--- a/src/app/api/monzo/transactions/route.ts
+++ b/src/app/api/monzo/transactions/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
 
-import { auth } from "@/lib/auth/auth";
+import { authServer } from "@/lib/auth/auth-server";
 import { db } from "@/lib/db";
 import {
   monzoMerchants,
@@ -13,7 +13,7 @@ import { getDatabaseMerchant, getDatabaseTransaction } from "./utils";
 
 export async function POST(request: Request): Promise<NextResponse> {
   try {
-    const session = await auth.api.getSession({
+    const session = await authServer.api.getSession({
       headers: request.headers,
     });
 
@@ -24,7 +24,7 @@ export async function POST(request: Request): Promise<NextResponse> {
       );
     }
 
-    const { accessToken } = await auth.api.getAccessToken({
+    const { accessToken } = await authServer.api.getAccessToken({
       body: { providerId: "monzo", userId: session.user.id },
     });
 

--- a/src/lib/auth/auth-client.ts
+++ b/src/lib/auth/auth-client.ts
@@ -6,11 +6,14 @@ import {
 } from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
 
-import type { auth } from "./auth";
+import type { authServer } from "./auth-server";
 
 const { useSession, signIn, signOut } = createAuthClient({
   baseURL: process.env.NEXT_PUBLIC_APP_URL,
-  plugins: [inferAdditionalFields<typeof auth>(), genericOAuthClient()],
+  plugins: [
+    inferAdditionalFields<typeof authServer>(),
+    genericOAuthClient(),
+  ],
 });
 
 export { useSession, signIn, signOut };

--- a/src/lib/auth/auth-server.ts
+++ b/src/lib/auth/auth-server.ts
@@ -23,7 +23,7 @@ type MonzoUserInfo = {
   user_id: string;
 };
 
-export const auth = betterAuth({
+export const authServer = betterAuth({
   database: drizzleAdapter(db, {
     provider: "pg",
     schema: authSchema,
@@ -92,4 +92,4 @@ export const auth = betterAuth({
   ],
 });
 
-export type Session = typeof auth.$Infer.Session;
+export type Session = typeof authServer.$Infer.Session;

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -4,7 +4,6 @@ import { genericOAuth } from "better-auth/plugins";
 
 import { db } from "@/lib/db";
 import * as authSchema from "@/lib/db/schema/auth-schema";
-import type { MonzoUserInfo } from "@/types/monzo/user-info";
 
 if (
   !process.env.MONZO_CLIENT_ID ||
@@ -16,6 +15,13 @@ if (
 ) {
   throw new Error("Monzo env variables must be set");
 }
+
+type MonzoUserInfo = {
+  authenticated: boolean;
+  client_id: string;
+  client_ip: string;
+  user_id: string;
+};
 
 export const auth = betterAuth({
   database: drizzleAdapter(db, {

--- a/src/types/monzo/user-info.ts
+++ b/src/types/monzo/user-info.ts
@@ -1,6 +1,0 @@
-export type MonzoUserInfo = {
-  authenticated: boolean;
-  client_id: string;
-  client_ip: string;
-  user_id: string;
-};


### PR DESCRIPTION
Unpushed changes from #13 

Main changes include:
- Moved `MonzoUserInfo` from /types/monzo/user-info to 'auth' file where it is used
- Renamed 'auth' to 'auth-server' and 'auth' variable to 'authServer' for greater clarity of difference to 'auth-client'/'authClient'