### PR TITLE
feat/categories

### DIFF
--- a/.cursor/utils.md
+++ b/.cursor/utils.md
@@ -1,0 +1,46 @@
+## Util Functions
+
+### Use 'get' Prefix and Object Parameters for Multiple Arguments
+
+When a defining a utility function use the 'get' prefix and when it requires multiple parameters, use an object parameter pattern for better readability and maintainability.
+
+```ts
+// ❌ Avoid
+function processData(data: Data, userId: string, options: Options) {
+  // ...
+}
+
+// ✅ Prefer
+function getData({
+  data,
+  userId,
+  options,
+}: {
+  data: Data;
+  userId: string;
+  options: Options;
+}) {
+  // ...
+}
+```
+
+Benefits:
+
+- Prefix makes it clear that its a utility
+- Named parameters make the code more self-documenting
+- Easier to add/remove parameters without breaking function signatures
+- Better IDE support with parameter hints
+- Parameters are more explicit at the call site
+
+### When to Use Object Parameters
+
+- When a function has more than 2 parameters
+- When parameters are related and form a logical group
+- When parameters might need to be extended in the future
+- When parameter order is not immediately obvious
+
+### When to Use Regular Parameters
+
+- For single parameters
+- For very simple functions with 2 or fewer parameters
+- When parameter order is obvious and conventional (e.g., `map(callback, array)`)

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll": "explicit"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
+}

--- a/src/app/(pages)/categories/[id]/merchants/page.tsx
+++ b/src/app/(pages)/categories/[id]/merchants/page.tsx
@@ -1,0 +1,48 @@
+import type { JSX } from "react";
+import { headers } from "next/headers";
+
+async function CategoryMerchantsPage({
+  params,
+}: {
+  params: { id: string };
+}): Promise<JSX.Element> {
+  const { id } = await params;
+
+  const headersList = await headers();
+  const cookie = headersList.get("cookie");
+
+  const accountRes = await fetch(
+    "http://localhost:3001/api/monzo/accounts",
+    { headers: headersList }
+  );
+  if (!accountRes.ok) {
+    const error = await accountRes.text();
+    throw new Error(JSON.stringify(error, null, 2));
+  }
+  const { account } = await accountRes.json();
+
+  const response = await fetch(
+    `http://localhost:3001/api/categories/${id}/merchants`,
+    {
+      method: "POST",
+      headers: {
+        ...(cookie ? { cookie } : {}),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ accountId: account.id }),
+    }
+  );
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(JSON.stringify(error, null, 2));
+  }
+  const merchants = await response.json();
+
+  return (
+    <div>
+      <pre>{JSON.stringify(merchants, null, 2)}</pre>
+    </div>
+  );
+}
+
+export default CategoryMerchantsPage;

--- a/src/app/(pages)/categories/[id]/page.tsx
+++ b/src/app/(pages)/categories/[id]/page.tsx
@@ -1,0 +1,113 @@
+"use server";
+
+import type { JSX } from "react";
+import { headers } from "next/headers";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+
+async function deleteCategory(id: string): Promise<void> {
+  "use server";
+
+  const headersList = await headers();
+  const cookie = headersList.get("cookie");
+
+  const response = await fetch(
+    `http://localhost:3001/api/categories/${id}`,
+    {
+      method: "DELETE",
+      headers: {
+        ...(cookie ? { cookie } : {}),
+      },
+    }
+  );
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(error);
+  }
+
+  redirect("/categories");
+}
+
+async function updateCategory(
+  id: string,
+  formData: FormData
+): Promise<void> {
+  "use server";
+
+  const name = formData.get("name");
+  if (!name || typeof name !== "string") {
+    throw new Error("Name is required");
+  }
+
+  const headersList = await headers();
+  const cookie = headersList.get("cookie");
+
+  const response = await fetch(
+    `http://localhost:3001/api/categories/${id}`,
+    {
+      method: "PUT",
+      headers: {
+        ...(cookie ? { cookie } : {}),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ name }),
+    }
+  );
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(error);
+  }
+
+  redirect("/categories");
+}
+
+async function CategoryPage({
+  params,
+}: {
+  params: { id: string };
+}): Promise<JSX.Element> {
+  const { id } = await params;
+
+  const categoryRes = await fetch(
+    `http://localhost:3001/api/categories/${id}`,
+    { headers: await headers() }
+  );
+  if (!categoryRes.ok) {
+    const error = await categoryRes.text();
+    throw new Error(JSON.stringify(error, null, 2));
+  }
+  const category = await categoryRes.json();
+
+  const updateCategoryWithId = updateCategory.bind(null, id);
+  const deleteCategoryWithId = deleteCategory.bind(null, id);
+
+  return (
+    <div>
+      <pre>{JSON.stringify(category, null, 2)}</pre>
+      <form action={deleteCategoryWithId}>
+        <button type="submit">Delete</button>
+      </form>
+      <h1>Edit</h1>
+      <form action={updateCategoryWithId}>
+        <div>
+          <label htmlFor="name">Category Name</label>
+          <input
+            type="text"
+            id="name"
+            name="name"
+            required
+            placeholder="Enter category name"
+            defaultValue={category.name}
+          />
+        </div>
+        <button type="submit">Update</button>
+      </form>
+      <Link href={`/categories/${id}/transactions`}>Transactions</Link>
+      <Link href={`/categories/${id}/merchants`}>Merchants</Link>
+    </div>
+  );
+}
+
+export default CategoryPage;

--- a/src/app/(pages)/categories/[id]/transactions/page.tsx
+++ b/src/app/(pages)/categories/[id]/transactions/page.tsx
@@ -1,0 +1,50 @@
+"use server";
+
+import type { JSX } from "react";
+import { headers } from "next/headers";
+
+async function CategoryTransactionsPage({
+  params,
+}: {
+  params: { id: string };
+}): Promise<JSX.Element> {
+  const { id } = await params;
+
+  const headersList = await headers();
+  const cookie = headersList.get("cookie");
+
+  const accountRes = await fetch(
+    "http://localhost:3001/api/monzo/accounts",
+    { headers: headersList }
+  );
+  if (!accountRes.ok) {
+    const error = await accountRes.text();
+    throw new Error(JSON.stringify(error, null, 2));
+  }
+  const { account } = await accountRes.json();
+
+  const transactionsRes = await fetch(
+    `http://localhost:3001/api/categories/${id}/transactions`,
+    {
+      method: "POST",
+      headers: {
+        ...(cookie ? { cookie } : {}),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ accountId: account.id }),
+    }
+  );
+  if (!transactionsRes.ok) {
+    const error = await transactionsRes.text();
+    throw new Error(JSON.stringify(error, null, 2));
+  }
+  const transactions = await transactionsRes.json();
+
+  return (
+    <div>
+      <pre>{JSON.stringify(transactions, null, 2)}</pre>
+    </div>
+  );
+}
+
+export default CategoryTransactionsPage;

--- a/src/app/(pages)/categories/create/page.tsx
+++ b/src/app/(pages)/categories/create/page.tsx
@@ -1,0 +1,54 @@
+import type { JSX } from "react";
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+
+async function createCategory(formData: FormData): Promise<void> {
+  "use server";
+
+  const name = formData.get("name");
+  if (!name || typeof name !== "string") {
+    alert("Name is required");
+    return;
+  }
+
+  const headersList = await headers();
+  const cookie = headersList.get("cookie");
+
+  const response = await fetch("http://localhost:3001/api/categories", {
+    method: "POST",
+    headers: {
+      ...(cookie ? { cookie } : {}),
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ name }),
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    alert(error);
+    return;
+  }
+
+  redirect("/categories");
+}
+
+export default function CreateCategoryPage(): JSX.Element {
+  return (
+    <div>
+      <h1>Create New Category</h1>
+      <form action={createCategory}>
+        <div>
+          <label htmlFor="name">Category Name</label>
+          <input
+            type="text"
+            id="name"
+            name="name"
+            required
+            placeholder="Enter category name"
+          />
+        </div>
+        <button type="submit">Create</button>
+      </form>
+    </div>
+  );
+}

--- a/src/app/(pages)/categories/page.tsx
+++ b/src/app/(pages)/categories/page.tsx
@@ -1,0 +1,36 @@
+import type { JSX } from "react";
+import { headers } from "next/headers";
+import Link from "next/link";
+
+import type { Category } from "@/types/category";
+
+async function CategoriesPage(): Promise<JSX.Element> {
+  const response = await fetch("http://localhost:3001/api/categories", {
+    headers: await headers(),
+  });
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(JSON.stringify(error, null, 2));
+  }
+  const { categories } = (await response.json()) as {
+    categories: Category[];
+  };
+
+  return (
+    <div>
+      <Link href="/categories/create">Create new category</Link>
+
+      {categories.length > 0 &&
+        categories.map((category) => (
+          <div key={category.id}>
+            <pre>{JSON.stringify(category, null, 2)}</pre>
+            <Link href={`/categories/${category.id}`}>
+              {category.name}
+            </Link>
+          </div>
+        ))}
+    </div>
+  );
+}
+
+export default CategoriesPage;

--- a/src/app/(pages)/page.tsx
+++ b/src/app/(pages)/page.tsx
@@ -18,6 +18,8 @@ export default function Home(): JSX.Element {
 
       <Link href="/accounts">Accounts</Link>
 
+      <Link href="/categories">Categories</Link>
+
       <pre>{JSON.stringify(session, null, 2)}</pre>
       <button
         onClick={async (e) => {

--- a/src/app/api/categories/[id]/merchants/route.ts
+++ b/src/app/api/categories/[id]/merchants/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+import { and, eq } from "drizzle-orm";
+
+import { authServer } from "@/lib/auth/auth-server";
+import { db } from "@/lib/db";
+import { monzoMerchants } from "@/lib/db/schema/monzo-schema";
+
+export async function POST(
+  req: Request,
+  { params }: { params: { id: string } }
+): Promise<NextResponse> {
+  try {
+    const session = await authServer.api.getSession({
+      headers: req.headers,
+    });
+
+    if (!session) {
+      return new NextResponse("Unauthorized", { status: 401 });
+    }
+
+    const { id: categoryId } = await params;
+    const body = await req.json();
+    const { accountId } = body;
+
+    const merchants = await db
+      .select()
+      .from(monzoMerchants)
+      .where(
+        and(
+          eq(monzoMerchants.categoryId, categoryId),
+          eq(monzoMerchants.accountId, accountId)
+        )
+      )
+      .orderBy(monzoMerchants.name);
+
+    return NextResponse.json(merchants);
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : "An unexpected error occurred";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/categories/[id]/route.ts
+++ b/src/app/api/categories/[id]/route.ts
@@ -54,6 +54,7 @@ export async function PUT(
       return new NextResponse("Unauthorized", { status: 401 });
     }
 
+    const userId = session.user.id;
     const body = await req.json();
     const { name } = body;
 
@@ -87,7 +88,7 @@ export async function PUT(
       .where(
         and(
           eq(monzoCategories.id, params.id),
-          eq(monzoCategories.userId, session.user.id)
+          eq(monzoCategories.userId, userId)
         )
       )
       .returning();
@@ -119,12 +120,14 @@ export async function DELETE(
       return new NextResponse("Unauthorized", { status: 401 });
     }
 
+    const userId = session.user.id;
+
     const category = await db
       .delete(monzoCategories)
       .where(
         and(
           eq(monzoCategories.id, params.id),
-          eq(monzoCategories.userId, session.user.id)
+          eq(monzoCategories.userId, userId)
         )
       )
       .returning();

--- a/src/app/api/categories/[id]/route.ts
+++ b/src/app/api/categories/[id]/route.ts
@@ -1,0 +1,144 @@
+import { NextResponse } from "next/server";
+import { and, eq, not } from "drizzle-orm";
+
+import { authServer } from "@/lib/auth/auth-server";
+import { db } from "@/lib/db";
+import { monzoCategories } from "@/lib/db/schema/monzo-schema";
+
+export async function GET(
+  request: Request,
+  { params }: { params: { id: string } }
+): Promise<NextResponse> {
+  try {
+    const session = await authServer.api.getSession({
+      headers: request.headers,
+    });
+
+    if (!session) {
+      return new NextResponse("Unauthorized", { status: 401 });
+    }
+
+    const userId = session.user.id;
+
+    const [category] = await db
+      .select()
+      .from(monzoCategories)
+      .where(
+        and(
+          eq(monzoCategories.userId, userId),
+          eq(monzoCategories.id, params.id)
+        )
+      )
+      .limit(1);
+
+    return NextResponse.json(category);
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : "An unexpected error occurred";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function PUT(
+  req: Request,
+  { params }: { params: { id: string } }
+): Promise<NextResponse> {
+  try {
+    const session = await authServer.api.getSession({
+      headers: req.headers,
+    });
+
+    if (!session) {
+      return new NextResponse("Unauthorized", { status: 401 });
+    }
+
+    const body = await req.json();
+    const { name } = body;
+
+    if (!name) {
+      return new NextResponse("Name is required", { status: 400 });
+    }
+
+    // Check if another category with the same name exists for this user
+    const existingCategory = await db
+      .select()
+      .from(monzoCategories)
+      .where(
+        and(
+          eq(monzoCategories.name, name.trim()),
+          eq(monzoCategories.userId, session.user.id),
+          // Exclude the current category being updated
+          not(eq(monzoCategories.id, params.id))
+        )
+      )
+      .limit(1);
+
+    if (existingCategory.length > 0) {
+      return new NextResponse("Category with this name already exists", {
+        status: 400,
+      });
+    }
+
+    const category = await db
+      .update(monzoCategories)
+      .set({ name })
+      .where(
+        and(
+          eq(monzoCategories.id, params.id),
+          eq(monzoCategories.userId, session.user.id)
+        )
+      )
+      .returning();
+
+    if (!category.length) {
+      return new NextResponse("Category not found", { status: 404 });
+    }
+
+    return NextResponse.json(category[0]);
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : "An unexpected error occurred";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  req: Request,
+  { params }: { params: { id: string } }
+): Promise<NextResponse> {
+  try {
+    const session = await authServer.api.getSession({
+      headers: req.headers,
+    });
+
+    if (!session) {
+      return new NextResponse("Unauthorized", { status: 401 });
+    }
+
+    const category = await db
+      .delete(monzoCategories)
+      .where(
+        and(
+          eq(monzoCategories.id, params.id),
+          eq(monzoCategories.userId, session.user.id)
+        )
+      )
+      .returning();
+
+    if (!category.length) {
+      return new NextResponse("Category not found", { status: 404 });
+    }
+
+    return new NextResponse(null, { status: 204 });
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : "An unexpected error occurred";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/categories/[id]/transactions/route.ts
+++ b/src/app/api/categories/[id]/transactions/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+import { and, desc, eq } from "drizzle-orm";
+
+import { authServer } from "@/lib/auth/auth-server";
+import { db } from "@/lib/db";
+import { monzoTransactions } from "@/lib/db/schema/monzo-schema";
+
+export async function POST(
+  req: Request,
+  { params }: { params: { id: string } }
+): Promise<NextResponse> {
+  try {
+    const session = await authServer.api.getSession({
+      headers: req.headers,
+    });
+
+    if (!session) {
+      return new NextResponse("Unauthorized", { status: 401 });
+    }
+
+    const { id: categoryId } = await params;
+    const body = await req.json();
+    const { accountId } = body;
+
+    const transactions = await db
+      .select()
+      .from(monzoTransactions)
+      .where(
+        and(
+          eq(monzoTransactions.categoryId, categoryId),
+          eq(monzoTransactions.accountId, accountId)
+        )
+      )
+      .orderBy(desc(monzoTransactions.created));
+
+    return NextResponse.json(transactions);
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : "An unexpected error occurred";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -1,0 +1,87 @@
+import { NextResponse } from "next/server";
+import { and, eq } from "drizzle-orm";
+
+import { authServer } from "@/lib/auth/auth-server";
+import { db } from "@/lib/db";
+import { monzoCategories } from "@/lib/db/schema/monzo-schema";
+
+export async function GET(request: Request): Promise<NextResponse> {
+  try {
+    const session = await authServer.api.getSession({
+      headers: request.headers,
+    });
+
+    if (!session?.user?.id) {
+      return new NextResponse("Unauthorized", { status: 401 });
+    }
+
+    const categories = await db
+      .select()
+      .from(monzoCategories)
+      .where(eq(monzoCategories.userId, session.user.id));
+
+    return NextResponse.json({ categories });
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : "An unexpected error occurred";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function POST(req: Request): Promise<NextResponse> {
+  try {
+    const session = await authServer.api.getSession({
+      headers: req.headers,
+    });
+
+    if (!session) {
+      return new NextResponse("Unauthorized", { status: 401 });
+    }
+
+    const body = await req.json();
+    const { name } = body;
+
+    if (!name) {
+      return new NextResponse("Name is required", { status: 400 });
+    }
+
+    const userId = session?.user?.id;
+
+    const existingCategory = await db
+      .select()
+      .from(monzoCategories)
+      .where(
+        and(
+          eq(monzoCategories.name, name),
+          eq(monzoCategories.userId, userId)
+        )
+      )
+      .limit(1);
+
+    if (existingCategory.length > 0) {
+      return new NextResponse("Category with this name already exists", {
+        status: 400,
+      });
+    }
+
+    const [category] = await db
+      .insert(monzoCategories)
+      .values({
+        id: crypto.randomUUID(),
+        name: name.trim(),
+        isMonzo: false,
+        userId,
+      })
+      .returning();
+
+    return NextResponse.json(category);
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : "An unexpected error occurred";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -11,14 +11,16 @@ export async function GET(request: Request): Promise<NextResponse> {
       headers: request.headers,
     });
 
-    if (!session?.user?.id) {
+    if (!session) {
       return new NextResponse("Unauthorized", { status: 401 });
     }
+
+    const userId = session.user.id;
 
     const categories = await db
       .select()
       .from(monzoCategories)
-      .where(eq(monzoCategories.userId, session.user.id));
+      .where(eq(monzoCategories.userId, userId));
 
     return NextResponse.json({ categories });
   } catch (error) {
@@ -48,7 +50,6 @@ export async function POST(req: Request): Promise<NextResponse> {
     }
 
     const userId = session?.user?.id;
-
     const existingCategory = await db
       .select()
       .from(monzoCategories)

--- a/src/app/api/monzo/transactions/constants.ts
+++ b/src/app/api/monzo/transactions/constants.ts
@@ -1,0 +1,25 @@
+import type { TransactionCategory } from "@/types/common";
+
+export const DEFAULT_CATEGORIES: {
+  id: TransactionCategory;
+  name: string;
+}[] = [
+  { id: "entertainment", name: "Entertainment" },
+  { id: "general", name: "General" },
+  { id: "groceries", name: "Groceries" },
+  { id: "eating_out", name: "Eating Out" },
+  { id: "charity", name: "Charity" },
+  { id: "expenses", name: "Expenses" },
+  { id: "family", name: "Family" },
+  { id: "finances", name: "Finances" },
+  { id: "gifts", name: "Gifts" },
+  { id: "personal_care", name: "Personal Care" },
+  { id: "shopping", name: "Shopping" },
+  { id: "transport", name: "Transport" },
+  { id: "income", name: "Income" },
+  { id: "savings", name: "Savings" },
+  { id: "transfers", name: "Transfers" },
+  { id: "holidays", name: "Holidays" },
+];
+
+export const DEFAULT_CATEGORIES_IDS = DEFAULT_CATEGORIES.map((c) => c.id);

--- a/src/app/api/monzo/transactions/utils.ts
+++ b/src/app/api/monzo/transactions/utils.ts
@@ -1,20 +1,10 @@
-import type { monzoMerchants, monzoTransactions } from "@/lib/db";
+import type {
+  monzoMerchants,
+  monzoTransactions,
+} from "@/lib/db/schema/monzo-schema";
 import type { TransactionMerchant } from "@/types/common";
 
 import type { MonzoTransaction } from "./types";
-
-export function getDatabaseMerchant(
-  merchant: TransactionMerchant,
-  accountId: string
-): typeof monzoMerchants.$inferInsert {
-  const { group_id, disable_feedback, ...other } = merchant;
-  return {
-    ...other,
-    groupId: group_id,
-    disableFeedback: disable_feedback,
-    accountId,
-  };
-}
 
 export function getDatabaseTransaction(
   transaction: MonzoTransaction
@@ -27,6 +17,7 @@ export function getDatabaseTransaction(
     settled,
     merchant,
     account_id,
+    category,
     ...other
   } = transaction;
 
@@ -40,5 +31,22 @@ export function getDatabaseTransaction(
     localCurrency: local_currency,
     accountId: account_id,
     merchantId: merchant ? merchant.id : null,
+    categoryId: category,
+  };
+}
+
+export function getDatabaseMerchant(
+  merchant: TransactionMerchant,
+  accountId: string
+): typeof monzoMerchants.$inferInsert {
+  const { group_id, category, disable_feedback, ...other } = merchant;
+
+  return {
+    ...other,
+    groupId: group_id,
+    disableFeedback: disable_feedback,
+    // Use 'general' as default category if none is provided
+    categoryId: category || "general",
+    accountId,
   };
 }

--- a/src/lib/db/migrations/0003_monzo_categories.sql
+++ b/src/lib/db/migrations/0003_monzo_categories.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "monzo_categories" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"is_monzo" boolean DEFAULT true NOT NULL,
+	"user_id" text,
+	"created_at" timestamp NOT NULL,
+	"updated_at" timestamp NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "monzo_merchants" RENAME COLUMN "category" TO "category_id";--> statement-breakpoint
+ALTER TABLE "monzo_transactions" RENAME COLUMN "category" TO "category_id";--> statement-breakpoint
+ALTER TABLE "monzo_categories" ADD CONSTRAINT "monzo_categories_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "monzo_merchants" ADD CONSTRAINT "monzo_merchants_category_id_monzo_categories_id_fk" FOREIGN KEY ("category_id") REFERENCES "public"."monzo_categories"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "monzo_transactions" ADD CONSTRAINT "monzo_transactions_category_id_monzo_categories_id_fk" FOREIGN KEY ("category_id") REFERENCES "public"."monzo_categories"("id") ON DELETE no action ON UPDATE no action;

--- a/src/lib/db/migrations/meta/0003_snapshot.json
+++ b/src/lib/db/migrations/meta/0003_snapshot.json
@@ -1,0 +1,732 @@
+{
+  "id": "247a75ee-6087-4bca-8de3-1f6ffed3d9aa",
+  "prevId": "a43e160f-f4cc-469d-9dd5-50a79a8a5155",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_ip": {
+          "name": "client_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "user_user_id_unique": {
+          "name": "user_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.monzo_accounts": {
+      "name": "monzo_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_type": {
+          "name": "owner_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_flex": {
+          "name": "is_flex",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_type": {
+          "name": "product_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owners": {
+          "name": "owners",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_number": {
+          "name": "account_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_code": {
+          "name": "sort_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "monzo_accounts_user_id_user_id_fk": {
+          "name": "monzo_accounts_user_id_user_id_fk",
+          "tableFrom": "monzo_accounts",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.monzo_categories": {
+      "name": "monzo_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_monzo": {
+          "name": "is_monzo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "monzo_categories_user_id_user_id_fk": {
+          "name": "monzo_categories_user_id_user_id_fk",
+          "tableFrom": "monzo_categories",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.monzo_merchants": {
+      "name": "monzo_merchants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "online": {
+          "name": "online",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "atm": {
+          "name": "atm",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disable_feedback": {
+          "name": "disable_feedback",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "monzo_merchants_category_id_monzo_categories_id_fk": {
+          "name": "monzo_merchants_category_id_monzo_categories_id_fk",
+          "tableFrom": "monzo_merchants",
+          "tableTo": "monzo_categories",
+          "columnsFrom": ["category_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "monzo_merchants_account_id_monzo_accounts_id_fk": {
+          "name": "monzo_merchants_account_id_monzo_accounts_id_fk",
+          "tableFrom": "monzo_merchants",
+          "tableTo": "monzo_accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.monzo_transactions": {
+      "name": "monzo_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settled": {
+          "name": "settled",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_amount": {
+          "name": "local_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_currency": {
+          "name": "local_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant_id": {
+          "name": "merchant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "monzo_transactions_category_id_monzo_categories_id_fk": {
+          "name": "monzo_transactions_category_id_monzo_categories_id_fk",
+          "tableFrom": "monzo_transactions",
+          "tableTo": "monzo_categories",
+          "columnsFrom": ["category_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "monzo_transactions_account_id_monzo_accounts_id_fk": {
+          "name": "monzo_transactions_account_id_monzo_accounts_id_fk",
+          "tableFrom": "monzo_transactions",
+          "tableTo": "monzo_accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "monzo_transactions_merchant_id_monzo_merchants_id_fk": {
+          "name": "monzo_transactions_merchant_id_monzo_merchants_id_fk",
+          "tableFrom": "monzo_transactions",
+          "tableTo": "monzo_merchants",
+          "columnsFrom": ["merchant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/lib/db/migrations/meta/_journal.json
+++ b/src/lib/db/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1749404742309,
       "tag": "0002_monzo_accounts_and_transactions",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1749584867773,
+      "tag": "0003_monzo_categories",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/db/schema/monzo-schema.ts
+++ b/src/lib/db/schema/monzo-schema.ts
@@ -9,6 +9,21 @@ import {
 
 import { user } from "./auth-schema";
 
+export const monzoCategories = pgTable("monzo_categories", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  isMonzo: boolean("is_monzo").notNull().default(true),
+  userId: text("user_id").references(() => user.id, {
+    onDelete: "cascade",
+  }),
+  createdAt: timestamp("created_at")
+    .$defaultFn(() => new Date())
+    .notNull(),
+  updatedAt: timestamp("updated_at")
+    .$defaultFn(() => new Date())
+    .notNull(),
+});
+
 export const monzoAccounts = pgTable("monzo_accounts", {
   id: text("id").primaryKey(),
   created: timestamp("created").notNull(),
@@ -37,7 +52,9 @@ export const monzoMerchants = pgTable("monzo_merchants", {
   name: text("name").notNull(),
   logo: text("logo").notNull(),
   emoji: text("emoji"),
-  category: text("category").notNull(),
+  categoryId: text("category_id")
+    .notNull()
+    .references(() => monzoCategories.id),
   online: boolean("online").notNull(),
   atm: boolean("atm").notNull(),
   address: jsonb("address").notNull(),
@@ -62,7 +79,9 @@ export const monzoTransactions = pgTable("monzo_transactions", {
   amount: numeric("amount").notNull(),
   currency: text("currency").notNull(),
   notes: text("notes"),
-  category: text("category").notNull(),
+  categoryId: text("category_id")
+    .notNull()
+    .references(() => monzoCategories.id),
   settled: timestamp("settled"),
   localAmount: numeric("local_amount").notNull(),
   localCurrency: text("local_currency").notNull(),

--- a/src/lib/db/schema/monzo-schema.ts
+++ b/src/lib/db/schema/monzo-schema.ts
@@ -1,3 +1,4 @@
+import { relations } from "drizzle-orm";
 import {
   boolean,
   jsonb,
@@ -23,6 +24,14 @@ export const monzoCategories = pgTable("monzo_categories", {
     .$defaultFn(() => new Date())
     .notNull(),
 });
+
+export const monzoCategoriesRelations = relations(
+  monzoCategories,
+  ({ many }) => ({
+    merchants: many(monzoMerchants),
+    transactions: many(monzoTransactions),
+  })
+);
 
 export const monzoAccounts = pgTable("monzo_accounts", {
   id: text("id").primaryKey(),
@@ -72,6 +81,17 @@ export const monzoMerchants = pgTable("monzo_merchants", {
     .notNull(),
 });
 
+export const monzoMerchantsRelations = relations(
+  monzoMerchants,
+  ({ one, many }) => ({
+    category: one(monzoCategories, {
+      fields: [monzoMerchants.categoryId],
+      references: [monzoCategories.id],
+    }),
+    transactions: many(monzoTransactions),
+  })
+);
+
 export const monzoTransactions = pgTable("monzo_transactions", {
   id: text("id").primaryKey(),
   created: timestamp("created").notNull(),
@@ -96,3 +116,17 @@ export const monzoTransactions = pgTable("monzo_transactions", {
     .$defaultFn(() => new Date())
     .notNull(),
 });
+
+export const monzoTransactionsRelations = relations(
+  monzoTransactions,
+  ({ one }) => ({
+    category: one(monzoCategories, {
+      fields: [monzoTransactions.categoryId],
+      references: [monzoCategories.id],
+    }),
+    merchant: one(monzoMerchants, {
+      fields: [monzoTransactions.merchantId],
+      references: [monzoMerchants.id],
+    }),
+  })
+);

--- a/src/types/category.ts
+++ b/src/types/category.ts
@@ -1,0 +1,5 @@
+export type Category = {
+  id: string;
+  name: string;
+  isMonzo: boolean;
+};


### PR DESCRIPTION
This PR makes the following changes:

- Added new `monzo_categories` table with `id`, `name`, `is_monzo` (to distinguish between custom and original monzo categories) and `user_id`

**Endpoints:**
- Refactored `/monzo/transactions` seeding route to create a categories table as well as link it to the merchants/transactions table 
  - Extracted handling of merchanges/categories from existing transactions data to separate `getMerchantsAndCategories` util
- Added `GET /api/categories` endpoint to fetch list of categories
- Added `POST /api/categories` endpoint to create a custom category
- Added `GET /api/categories/:id` to fetch a single category
- Added `PUT /api/categories/:id` to edit an existing category
- Added `DELETE /api/categories/:id` to delete a category
- Added `GET /api/categories/:id/transactions` to fetch all transactions belonging to a given category
- Added `GET /api/categories/:id/merchanges` to fetch all merchants belonging to a given category

**Pages:**
- Added `/categories` page which displays all the available categories for that user
- Added `/categories/create` page to allow users to create their own custom category
- Added `/categories/:id` page which allows users to see/delete/edit an existing category
- Added `/categories/:id/transactions` page which lists all the transactions for a given category
- Added `/categories/:id/merchants` page which lists all the merchants for a given category

**Other changes:**
- Added 'utils' markdown file to help Cursor chatbot/agents with how to define utilities functions