### PR TITLE
refactor/api/auth-middleware

### DIFF
--- a/src/app/api/categories/[id]/merchants/route.ts
+++ b/src/app/api/categories/[id]/merchants/route.ts
@@ -1,25 +1,15 @@
 import { NextResponse } from "next/server";
 import { and, eq } from "drizzle-orm";
 
-import { authServer } from "@/lib/auth/auth-server";
 import { db } from "@/lib/db";
 import { monzoMerchants } from "@/lib/db/schema/monzo-schema";
+import { withAuth } from "@/app/api/middleware";
 
-export async function POST(
-  req: Request,
-  { params }: { params: { id: string } }
-): Promise<NextResponse> {
-  try {
-    const session = await authServer.api.getSession({
-      headers: req.headers,
-    });
-
-    if (!session) {
-      return new NextResponse("Unauthorized", { status: 401 });
-    }
-
+// NOTE: this is a POST request even though we are fetching because of the request body
+export const POST = withAuth<{ params: { id: string } }>(
+  async ({ request, context: { params } }) => {
     const { id: categoryId } = await params;
-    const body = await req.json();
+    const body = await request.json();
     const { accountId } = body;
 
     const merchants = await db
@@ -34,11 +24,5 @@ export async function POST(
       .orderBy(monzoMerchants.name);
 
     return NextResponse.json(merchants);
-  } catch (error) {
-    const message =
-      error instanceof Error
-        ? error.message
-        : "An unexpected error occurred";
-    return NextResponse.json({ error: message }, { status: 500 });
   }
-}
+);

--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -1,88 +1,54 @@
 import { NextResponse } from "next/server";
 import { and, eq } from "drizzle-orm";
 
-import { authServer } from "@/lib/auth/auth-server";
 import { db } from "@/lib/db";
 import { monzoCategories } from "@/lib/db/schema/monzo-schema";
 
-export async function GET(request: Request): Promise<NextResponse> {
-  try {
-    const session = await authServer.api.getSession({
-      headers: request.headers,
-    });
+import { withAuth } from "../middleware";
 
-    if (!session) {
-      return new NextResponse("Unauthorized", { status: 401 });
-    }
+export const GET = withAuth(async ({ userId }) => {
+  const categories = await db
+    .select()
+    .from(monzoCategories)
+    .where(eq(monzoCategories.userId, userId));
 
-    const userId = session.user.id;
+  return NextResponse.json({ categories });
+});
 
-    const categories = await db
-      .select()
-      .from(monzoCategories)
-      .where(eq(monzoCategories.userId, userId));
+export const POST = withAuth(async ({ request, userId }) => {
+  const body = await request.json();
+  const { name } = body;
 
-    return NextResponse.json({ categories });
-  } catch (error) {
-    const message =
-      error instanceof Error
-        ? error.message
-        : "An unexpected error occurred";
-    return NextResponse.json({ error: message }, { status: 500 });
+  if (!name) {
+    return new NextResponse("Name is required", { status: 400 });
   }
-}
 
-export async function POST(req: Request): Promise<NextResponse> {
-  try {
-    const session = await authServer.api.getSession({
-      headers: req.headers,
-    });
-
-    if (!session) {
-      return new NextResponse("Unauthorized", { status: 401 });
-    }
-
-    const body = await req.json();
-    const { name } = body;
-
-    if (!name) {
-      return new NextResponse("Name is required", { status: 400 });
-    }
-
-    const userId = session?.user?.id;
-    const existingCategory = await db
-      .select()
-      .from(monzoCategories)
-      .where(
-        and(
-          eq(monzoCategories.name, name),
-          eq(monzoCategories.userId, userId)
-        )
+  const existingCategory = await db
+    .select()
+    .from(monzoCategories)
+    .where(
+      and(
+        eq(monzoCategories.name, name),
+        eq(monzoCategories.userId, userId)
       )
-      .limit(1);
+    )
+    .limit(1);
 
-    if (existingCategory.length > 0) {
-      return new NextResponse("Category with this name already exists", {
-        status: 400,
-      });
-    }
-
-    const [category] = await db
-      .insert(monzoCategories)
-      .values({
-        id: crypto.randomUUID(),
-        name: name.trim(),
-        isMonzo: false,
-        userId,
-      })
-      .returning();
-
-    return NextResponse.json(category);
-  } catch (error) {
-    const message =
-      error instanceof Error
-        ? error.message
-        : "An unexpected error occurred";
-    return NextResponse.json({ error: message }, { status: 500 });
+  if (existingCategory.length > 0) {
+    return new NextResponse("Category with this name already exists", {
+      status: 400,
+    });
   }
-}
+
+  const [category] = await db
+    .insert(monzoCategories)
+    .values({
+      id: crypto.randomUUID(),
+      name: name.trim(),
+      isMonzo: false,
+      userId,
+    })
+    .returning();
+
+  return NextResponse.json(category);
+});

--- a/src/app/api/middleware.ts
+++ b/src/app/api/middleware.ts
@@ -1,0 +1,50 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+import { authServer } from "@/lib/auth/auth-server";
+
+type HandlerContext = { params: Record<string, string> };
+
+type Handler<Context extends HandlerContext> = (
+  request: NextRequest,
+  context: Context
+) => Promise<Response>;
+
+export function withErrorHandling<Context extends HandlerContext>(
+  handler: Handler<Context>
+): Handler<Context> {
+  return async (request, context): Promise<Response> => {
+    try {
+      return await handler(request, context);
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "An unexpected error occurred";
+      return NextResponse.json({ error: message }, { status: 500 });
+    }
+  };
+}
+
+export function withAuth<Context extends HandlerContext>(
+  handler: (args: {
+    request: NextRequest;
+    context: Context;
+    userId: string;
+  }) => Promise<Response>
+): Handler<Context> {
+  return withErrorHandling(
+    async function (request, context): Promise<Response> {
+      const session = await authServer.api.getSession({
+        headers: request.headers,
+      });
+
+      if (!session) {
+        return new NextResponse("Unauthorized", { status: 401 });
+      }
+
+      const userId = session.user.id;
+      return handler({ request, context, userId });
+    }
+  );
+}

--- a/src/app/api/middleware.ts
+++ b/src/app/api/middleware.ts
@@ -48,3 +48,26 @@ export function withAuth<Context extends HandlerContext>(
     }
   );
 }
+
+export function withAuthAccessToken<Context extends HandlerContext>(
+  handler: (args: {
+    request: NextRequest;
+    context: Context;
+    userId: string;
+    accessToken: string;
+  }) => Promise<Response>
+): Handler<Context> {
+  return withAuth(async function (args): Promise<Response> {
+    const { userId } = args;
+
+    const { accessToken } = await authServer.api.getAccessToken({
+      body: { providerId: "monzo", userId },
+    });
+
+    if (!accessToken) {
+      return NextResponse.json({ error: "Unauthorised" }, { status: 401 });
+    }
+
+    return handler({ ...args, accessToken });
+  });
+}

--- a/src/app/api/monzo/accounts/route.ts
+++ b/src/app/api/monzo/accounts/route.ts
@@ -1,91 +1,25 @@
 import { NextResponse } from "next/server";
-import { eq } from "drizzle-orm";
 
-import { authServer } from "@/lib/auth/auth-server";
 import { db, monzoAccounts } from "@/lib/db";
 
+import { withAuthAccessToken } from "../../middleware";
 import { fetchAccounts } from "./endpoints";
 import { getDatabaseAccount } from "./utils";
 
-export async function GET(request: Request): Promise<NextResponse> {
-  try {
-    const session = await authServer.api.getSession({
-      headers: request.headers,
-    });
+export const GET = withAuthAccessToken(async ({ userId, accessToken }) => {
+  const { accounts } = await fetchAccounts(accessToken);
+  const retailAccounts = accounts?.filter(
+    (account) => account.type === "uk_retail"
+  );
+  if (!retailAccounts.length)
+    throw Error("Unable to find any retail accounts");
 
-    if (!session) {
-      return NextResponse.json(
-        { error: "Unauthenticated" },
-        { status: 401 }
-      );
-    }
+  const insertedAccounts = await db
+    .insert(monzoAccounts)
+    .values(
+      retailAccounts.map((account) => getDatabaseAccount(account, userId))
+    )
+    .returning();
 
-    const [account] = await db
-      .select()
-      .from(monzoAccounts)
-      .where(eq(monzoAccounts.userId, session.user.id))
-      .limit(1);
-
-    return NextResponse.json({ account: account || null });
-  } catch (error) {
-    const message =
-      error instanceof Error
-        ? error.message
-        : "An unexpected error occurred";
-    return NextResponse.json({ error: message }, { status: 500 });
-  }
-}
-
-export async function POST(request: Request): Promise<NextResponse> {
-  try {
-    const session = await authServer.api.getSession({
-      headers: request.headers,
-    });
-
-    if (!session) {
-      return NextResponse.json(
-        { error: "Unauthenticated" },
-        { status: 401 }
-      );
-    }
-
-    const { accessToken } = await authServer.api.getAccessToken({
-      body: { providerId: "monzo", userId: session.user.id },
-    });
-
-    if (!accessToken) {
-      return NextResponse.json(
-        { error: "No access token" },
-        { status: 401 }
-      );
-    }
-
-    const { accounts } = await fetchAccounts(accessToken);
-    const retailAccounts = accounts?.filter(
-      (account) => account.type === "uk_retail"
-    );
-    if (!retailAccounts.length)
-      throw Error("Unable to find any retail accounts");
-
-    await db
-      .delete(monzoAccounts)
-      .where(eq(monzoAccounts.userId, session.user.id));
-
-    const insertedAccounts = await db
-      .insert(monzoAccounts)
-      .values(
-        retailAccounts.map((account) =>
-          getDatabaseAccount(account, session.user.id)
-        )
-      )
-      .returning();
-
-    return NextResponse.json({ accounts: insertedAccounts });
-  } catch (error) {
-    const message =
-      error instanceof Error
-        ? error.message
-        : "An unexpected error occurred";
-    return NextResponse.json({ error: message }, { status: 500 });
-  }
-}
+  return NextResponse.json({ accounts: insertedAccounts });
+});


### PR DESCRIPTION
This PR tidies up the internal endpoints by extracting out the **authentication session/access token checks** and **error handling** to higher-order-function (HOF) AKA middleware 😁 

This was inspired by the Auth0 Next.js v3 API: https://github.com/auth0/nextjs-auth0/tree/v3?tab=readme-ov-file#api-reference

🎯 Main changes are related to the `middleware.ts`, all the other changes follow from this:
- Added generic `withErrorHandling` HOF that avoid having to write try/catch for every handler
- Added `withAuth` HOF that avoids having to check if the session exists and returns the `userId` as part of the returned function (NOTE: `withAuth` calls `withErrorHandling` to avoid having to call both HOF everywhere)
- Added `withAuthAccessToken` HOF for endpoints/handlers that require an access token (NOTE: `withAuthAccessToken` calls `withAuth` since it requires the session data, specifically the `userId`)