### PR TITLE
refactor/api/response-standardisation

### DIFF
--- a/src/app/(pages)/accounts/page.tsx
+++ b/src/app/(pages)/accounts/page.tsx
@@ -1,8 +1,20 @@
 "use client";
 
-import type { JSX } from "react";
+import { useEffect, useState, type JSX } from "react";
 
 function AccountsPage(): JSX.Element {
+  const [account, setAccount] = useState(null);
+
+  useEffect(() => {
+    const fetchAccount = async (): Promise<void> => {
+      const response = await fetch("/api/accounts");
+      if (!response.ok) throw Error("Failed to fetch accounts");
+      const { data: account } = await response.json();
+      setAccount(account);
+    };
+    fetchAccount();
+  }, [setAccount]);
+
   const handleSeedAccounts = async (): Promise<void> => {
     const response = await fetch("/api/monzo/accounts", {
       method: "POST",
@@ -12,6 +24,7 @@ function AccountsPage(): JSX.Element {
 
   return (
     <div>
+      <pre>{JSON.stringify(account, null, 2)}</pre>
       <button onClick={handleSeedAccounts}>Seed accounts data</button>
     </div>
   );

--- a/src/app/(pages)/categories/[id]/merchants/page.tsx
+++ b/src/app/(pages)/categories/[id]/merchants/page.tsx
@@ -11,15 +11,17 @@ async function CategoryMerchantsPage({
   const headersList = await headers();
   const cookie = headersList.get("cookie");
 
-  const accountRes = await fetch(
-    "http://localhost:3001/api/monzo/accounts",
-    { headers: headersList }
-  );
+  const accountRes = await fetch("http://localhost:3001/api/accounts", {
+    headers: headersList,
+  });
   if (!accountRes.ok) {
     const error = await accountRes.text();
     throw new Error(JSON.stringify(error, null, 2));
   }
-  const { account } = await accountRes.json();
+  const { data: account } = await accountRes.json();
+  if (!account) {
+    throw new Error("No account found");
+  }
 
   const response = await fetch(
     `http://localhost:3001/api/categories/${id}/merchants`,
@@ -36,7 +38,7 @@ async function CategoryMerchantsPage({
     const error = await response.text();
     throw new Error(JSON.stringify(error, null, 2));
   }
-  const merchants = await response.json();
+  const { data: merchants } = await response.json();
 
   return (
     <div>

--- a/src/app/(pages)/categories/[id]/page.tsx
+++ b/src/app/(pages)/categories/[id]/page.tsx
@@ -78,7 +78,7 @@ async function CategoryPage({
     const error = await categoryRes.text();
     throw new Error(JSON.stringify(error, null, 2));
   }
-  const category = await categoryRes.json();
+  const { data: category } = await categoryRes.json();
 
   const updateCategoryWithId = updateCategory.bind(null, id);
   const deleteCategoryWithId = deleteCategory.bind(null, id);

--- a/src/app/(pages)/categories/[id]/transactions/page.tsx
+++ b/src/app/(pages)/categories/[id]/transactions/page.tsx
@@ -13,15 +13,17 @@ async function CategoryTransactionsPage({
   const headersList = await headers();
   const cookie = headersList.get("cookie");
 
-  const accountRes = await fetch(
-    "http://localhost:3001/api/monzo/accounts",
-    { headers: headersList }
-  );
+  const accountRes = await fetch("http://localhost:3001/api/accounts", {
+    headers: headersList,
+  });
   if (!accountRes.ok) {
     const error = await accountRes.text();
     throw new Error(JSON.stringify(error, null, 2));
   }
-  const { account } = await accountRes.json();
+  const { data: account } = await accountRes.json();
+  if (!account) {
+    throw new Error("No account found");
+  }
 
   const transactionsRes = await fetch(
     `http://localhost:3001/api/categories/${id}/transactions`,
@@ -38,7 +40,7 @@ async function CategoryTransactionsPage({
     const error = await transactionsRes.text();
     throw new Error(JSON.stringify(error, null, 2));
   }
-  const transactions = await transactionsRes.json();
+  const { data: transactions } = await transactionsRes.json();
 
   return (
     <div>

--- a/src/app/(pages)/categories/page.tsx
+++ b/src/app/(pages)/categories/page.tsx
@@ -12,8 +12,8 @@ async function CategoriesPage(): Promise<JSX.Element> {
     const error = await response.text();
     throw new Error(JSON.stringify(error, null, 2));
   }
-  const { categories } = (await response.json()) as {
-    categories: Category[];
+  const { data: categories } = (await response.json()) as {
+    data: Category[];
   };
 
   return (

--- a/src/app/(pages)/transactions/page.tsx
+++ b/src/app/(pages)/transactions/page.tsx
@@ -4,9 +4,10 @@ import type { JSX } from "react";
 
 function TransactionsPage(): JSX.Element {
   const handleSeedTransactions = async (): Promise<void> => {
-    const accountResponse = await fetch("/api/monzo/accounts");
+    const accountResponse = await fetch("/api/accounts");
     if (!accountResponse.ok) throw Error("Failed to fetch account");
-    const { account } = await accountResponse.json();
+    const { data: account } = await accountResponse.json();
+    if (!account) throw Error("No account found");
 
     const transactionResponse = await fetch("/api/monzo/transactions", {
       method: "POST",

--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+
+import { db } from "@/lib/db";
+import { monzoAccounts } from "@/lib/db/schema/monzo-schema";
+
+import { withAuth } from "../middleware";
+
+export const GET = withAuth<typeof monzoAccounts.$inferSelect>(
+  async ({ userId }) => {
+    const [account] = await db
+      .select()
+      .from(monzoAccounts)
+      .where(eq(monzoAccounts.userId, userId));
+
+    return NextResponse.json({ success: true, data: account });
+  }
+);

--- a/src/app/api/categories/[id]/merchants/route.ts
+++ b/src/app/api/categories/[id]/merchants/route.ts
@@ -6,23 +6,24 @@ import { monzoMerchants } from "@/lib/db/schema/monzo-schema";
 import { withAuth } from "@/app/api/middleware";
 
 // NOTE: this is a POST request even though we are fetching because of the request body
-export const POST = withAuth<{ params: { id: string } }>(
-  async ({ request, context: { params } }) => {
-    const { id: categoryId } = await params;
-    const body = await request.json();
-    const { accountId } = body;
+export const POST = withAuth<
+  (typeof monzoMerchants.$inferSelect)[],
+  { params: { id: string } }
+>(async ({ request, context: { params } }) => {
+  const { id: categoryId } = await params;
+  const body = await request.json();
+  const { accountId } = body;
 
-    const merchants = await db
-      .select()
-      .from(monzoMerchants)
-      .where(
-        and(
-          eq(monzoMerchants.categoryId, categoryId),
-          eq(monzoMerchants.accountId, accountId)
-        )
+  const merchants = await db
+    .select()
+    .from(monzoMerchants)
+    .where(
+      and(
+        eq(monzoMerchants.categoryId, categoryId),
+        eq(monzoMerchants.accountId, accountId)
       )
-      .orderBy(monzoMerchants.name);
+    )
+    .orderBy(monzoMerchants.name);
 
-    return NextResponse.json(merchants);
-  }
-);
+  return NextResponse.json({ success: true, data: merchants });
+});

--- a/src/app/api/categories/[id]/transactions/route.ts
+++ b/src/app/api/categories/[id]/transactions/route.ts
@@ -6,23 +6,24 @@ import { monzoTransactions } from "@/lib/db/schema/monzo-schema";
 import { withAuth } from "@/app/api/middleware";
 
 // NOTE: this is a POST request even though we are fetching because of the request body
-export const POST = withAuth<{ params: { id: string } }>(
-  async ({ request, context: { params } }) => {
-    const { id: categoryId } = await params;
-    const body = await request.json();
-    const { accountId } = body;
+export const POST = withAuth<
+  (typeof monzoTransactions.$inferSelect)[],
+  { params: { id: string } }
+>(async ({ request, context: { params } }) => {
+  const { id: categoryId } = await params;
+  const body = await request.json();
+  const { accountId } = body;
 
-    const transactions = await db
-      .select()
-      .from(monzoTransactions)
-      .where(
-        and(
-          eq(monzoTransactions.categoryId, categoryId),
-          eq(monzoTransactions.accountId, accountId)
-        )
+  const transactions = await db
+    .select()
+    .from(monzoTransactions)
+    .where(
+      and(
+        eq(monzoTransactions.categoryId, categoryId),
+        eq(monzoTransactions.accountId, accountId)
       )
-      .orderBy(desc(monzoTransactions.created));
+    )
+    .orderBy(desc(monzoTransactions.created));
 
-    return NextResponse.json(transactions);
-  }
-);
+  return NextResponse.json({ success: true, data: transactions });
+});

--- a/src/app/api/middleware.ts
+++ b/src/app/api/middleware.ts
@@ -3,17 +3,15 @@ import { NextResponse } from "next/server";
 
 import { authServer } from "@/lib/auth/auth-server";
 
-type HandlerContext = { params: Record<string, string> };
+import type { ApiResponse, Handler } from "./types";
 
-type Handler<Context extends HandlerContext> = (
-  request: NextRequest,
-  context: Context
-) => Promise<Response>;
-
-export function withErrorHandling<Context extends HandlerContext>(
-  handler: Handler<Context>
-): Handler<Context> {
-  return async (request, context): Promise<Response> => {
+export function withErrorHandling<Data, Context = unknown>(
+  handler: Handler<Data, Context>
+): Handler<Data, Context> {
+  return async (
+    request,
+    context
+  ): Promise<NextResponse<ApiResponse<Data>>> => {
     try {
       return await handler(request, context);
     } catch (error) {
@@ -21,43 +19,48 @@ export function withErrorHandling<Context extends HandlerContext>(
         error instanceof Error
           ? error.message
           : "An unexpected error occurred";
-      return NextResponse.json({ error: message }, { status: 500 });
+      return NextResponse.json(
+        { success: false, error: message },
+        { status: 500 }
+      );
     }
   };
 }
 
-export function withAuth<Context extends HandlerContext>(
+export function withAuth<Data, Context = unknown>(
   handler: (args: {
     request: NextRequest;
     context: Context;
     userId: string;
-  }) => Promise<Response>
-): Handler<Context> {
-  return withErrorHandling(
-    async function (request, context): Promise<Response> {
-      const session = await authServer.api.getSession({
-        headers: request.headers,
-      });
+  }) => Promise<NextResponse<ApiResponse<Data>>>
+): Handler<Data, Context> {
+  return withErrorHandling(async function (request, context): Promise<
+    NextResponse<ApiResponse<Data>>
+  > {
+    const session = await authServer.api.getSession({
+      headers: request.headers,
+    });
 
-      if (!session) {
-        return new NextResponse("Unauthorized", { status: 401 });
-      }
-
-      const userId = session.user.id;
-      return handler({ request, context, userId });
+    if (!session) {
+      return new NextResponse("Unauthorized", { status: 401 });
     }
-  );
+
+    const userId = session.user.id;
+    return handler({ request, context, userId });
+  });
 }
 
-export function withAuthAccessToken<Context extends HandlerContext>(
+export function withAuthAccessToken<Data, Context = unknown>(
   handler: (args: {
     request: NextRequest;
     context: Context;
     userId: string;
     accessToken: string;
-  }) => Promise<Response>
-): Handler<Context> {
-  return withAuth(async function (args): Promise<Response> {
+  }) => Promise<NextResponse<ApiResponse<Data>>>
+): Handler<Data, Context> {
+  return withAuth(async function (args): Promise<
+    NextResponse<ApiResponse<Data>>
+  > {
     const { userId } = args;
 
     const { accessToken } = await authServer.api.getAccessToken({
@@ -65,7 +68,10 @@ export function withAuthAccessToken<Context extends HandlerContext>(
     });
 
     if (!accessToken) {
-      return NextResponse.json({ error: "Unauthorised" }, { status: 401 });
+      return NextResponse.json(
+        { success: false, error: "Unauthorised" },
+        { status: 401 }
+      );
     }
 
     return handler({ ...args, accessToken });

--- a/src/app/api/monzo/accounts/route.ts
+++ b/src/app/api/monzo/accounts/route.ts
@@ -6,20 +6,24 @@ import { withAuthAccessToken } from "../../middleware";
 import { fetchAccounts } from "./endpoints";
 import { getDatabaseAccount } from "./utils";
 
-export const GET = withAuthAccessToken(async ({ userId, accessToken }) => {
-  const { accounts } = await fetchAccounts(accessToken);
-  const retailAccounts = accounts?.filter(
-    (account) => account.type === "uk_retail"
-  );
-  if (!retailAccounts.length)
-    throw Error("Unable to find any retail accounts");
+export const GET = withAuthAccessToken<typeof monzoAccounts.$inferInsert>(
+  async ({ userId, accessToken }) => {
+    const { accounts } = await fetchAccounts(accessToken);
+    const retailAccounts = accounts?.filter(
+      (account) => account.type === "uk_retail"
+    );
+    if (!retailAccounts.length)
+      throw Error("Unable to find any retail accounts");
 
-  const insertedAccounts = await db
-    .insert(monzoAccounts)
-    .values(
-      retailAccounts.map((account) => getDatabaseAccount(account, userId))
-    )
-    .returning();
+    const [insertedAccounts] = await db
+      .insert(monzoAccounts)
+      .values(
+        retailAccounts.map((account) =>
+          getDatabaseAccount(account, userId)
+        )
+      )
+      .returning();
 
-  return NextResponse.json({ accounts: insertedAccounts });
-});
+    return NextResponse.json({ success: true, data: insertedAccounts });
+  }
+);

--- a/src/app/api/monzo/transactions/route.ts
+++ b/src/app/api/monzo/transactions/route.ts
@@ -15,68 +15,68 @@ import {
   getMerchantsAndCategories,
 } from "./utils";
 
-export const POST = withAuthAccessToken(
-  async ({ request, userId, accessToken }) => {
-    // Get the account ID from the request body
-    const { accountId } = await request.json();
-    if (!accountId) {
-      return NextResponse.json(
-        { error: "Account ID is required" },
-        { status: 400 }
-      );
-    }
+export const POST = withAuthAccessToken<
+  (typeof monzoTransactions.$inferInsert)[]
+>(async ({ request, userId, accessToken }) => {
+  // Get the account ID from the request body
+  const { accountId } = await request.json();
+  if (!accountId) {
+    return NextResponse.json(
+      { success: false, error: "Account ID is required" },
+      { status: 400 }
+    );
+  }
 
-    const { transactions } = await fetchTransactions(
-      accessToken,
-      accountId
+  const { transactions } = await fetchTransactions(accessToken, accountId);
+
+  if (!transactions || transactions.length === 0) {
+    return NextResponse.json({
+      success: false,
+      error: "No transactions found",
+    });
+  }
+
+  // Process transactions to extract merchants and categories
+  const { merchants, customCategories } = getMerchantsAndCategories({
+    transactions,
+    userId,
+    accountId,
+  });
+
+  const insertedTransactions = await db.transaction(async (tx) => {
+    // Insert default categories
+    await tx.insert(monzoCategories).values(
+      DEFAULT_CATEGORIES.map((category) => ({
+        ...category,
+        isMonzo: true,
+        userId,
+      }))
     );
 
-    if (!transactions || transactions.length === 0) {
-      return NextResponse.json({ transactions: [] });
+    // Insert custom categories
+    const customCategoriesArray = Array.from(customCategories.values());
+    if (customCategoriesArray.length > 0) {
+      await tx.insert(monzoCategories).values(customCategoriesArray);
     }
 
-    // Process transactions to extract merchants and categories
-    const { merchants, customCategories } = getMerchantsAndCategories({
-      transactions,
-      userId,
-      accountId,
-    });
+    // Insert merchants
+    const merchantsArray = Array.from(merchants.values());
+    if (merchantsArray.length > 0) {
+      await tx.insert(monzoMerchants).values(merchantsArray);
+    }
 
-    const insertedTransactions = await db.transaction(async (tx) => {
-      // Insert default categories
-      await tx.insert(monzoCategories).values(
-        DEFAULT_CATEGORIES.map((category) => ({
-          ...category,
-          isMonzo: true,
-          userId,
-        }))
-      );
-
-      // Insert custom categories
-      const customCategoriesArray = Array.from(customCategories.values());
-      if (customCategoriesArray.length > 0) {
-        await tx.insert(monzoCategories).values(customCategoriesArray);
-      }
-
-      // Insert merchants
-      const merchantsArray = Array.from(merchants.values());
-      if (merchantsArray.length > 0) {
-        await tx.insert(monzoMerchants).values(merchantsArray);
-      }
-
-      // Insert transactions
-      const insertedTransactions = await tx
-        .insert(monzoTransactions)
-        .values(
-          transactions.map((transaction) =>
-            getDatabaseTransaction(transaction)
-          )
+    // Insert transactions
+    const insertedTransactions = await tx
+      .insert(monzoTransactions)
+      .values(
+        transactions.map((transaction) =>
+          getDatabaseTransaction(transaction)
         )
-        .returning();
+      )
+      .returning();
 
-      return insertedTransactions;
-    });
+    return insertedTransactions;
+  });
 
-    return NextResponse.json({ transactions: insertedTransactions });
-  }
-);
+  return NextResponse.json({ success: true, data: insertedTransactions });
+});

--- a/src/app/api/types.ts
+++ b/src/app/api/types.ts
@@ -1,0 +1,22 @@
+import type { NextRequest, NextResponse } from "next/server";
+
+export type Handler<Data, Context> = (
+  request: NextRequest,
+  context: Context
+) => Promise<NextResponse<ApiResponse<Data>>>;
+
+export type ApiErrorResponse = { success: false; error: string };
+
+export type ApiDataResponse<T> = { success: true; data?: T };
+
+export type ApiResponse<T> = ApiErrorResponse | ApiDataResponse<T>;
+
+export type PaginatedData<T> = {
+  data: T[];
+  pagination: {
+    count: number;
+    total: number;
+    page: number;
+    size: number;
+  };
+};

--- a/src/types/category.ts
+++ b/src/types/category.ts
@@ -2,4 +2,6 @@ export type Category = {
   id: string;
   name: string;
   isMonzo: boolean;
+  createdAt: Date;
+  updatedAt: Date;
 };


### PR DESCRIPTION
The main purpose of this PR is to add type safety to the API handlers via the middlewares (`withErrorHandling`, `withAuth` and `withAuthAccessToken`)

🎯 Main changes:
- Previously, the middlewares/handlers were just returning a generic `Response` type and there was no enforcement of data types.. This was replaced with `ApiResponse<T>` and most the changes in the routes followed from this.
```ts
import type { NextRequest, NextResponse } from "next/server";

export type Handler<Data, Context> = (
  request: NextRequest,
  context: Context
) => Promise<NextResponse<ApiResponse<Data>>>;

export type ApiErrorResponse = { success: false; error: string };

export type ApiDataResponse<T> = { success: true; data?: T };

export type ApiResponse<T> = ApiErrorResponse | ApiDataResponse<T>;

export type PaginatedData<T> = {
  data: T[];
  pagination: {
    count: number;
    total: number;
    page: number;
    size: number;
  };
};
```

👀 Other changes:
- Added new `/api/accounts` endpoint to fetch the account data for a given user (NOTE: when seeding we are only saving the UK retail account atm, so there's only a single account returned here)
- Fixed instances where `/api/monzo/accounts` (seeding) route was getting incorrectly called when instead, it should of been fetching from `/api/accounts` (e.g. in /categories/:id/merchants page, in /categories/:id/transactions page, /transactions (seeding) page  