### PR TITLE
refactor/rename-category-column-monzo-category

### DIFF
--- a/src/app/api/categories/[id]/merchants/route.ts
+++ b/src/app/api/categories/[id]/merchants/route.ts
@@ -23,7 +23,7 @@ export const POST = withAuth<
       updatedAt: false,
     },
     with: {
-      _category: {
+      category: {
         columns: {
           userId: false,
           createdAt: false,

--- a/src/app/api/categories/[id]/transactions/route.ts
+++ b/src/app/api/categories/[id]/transactions/route.ts
@@ -22,7 +22,7 @@ export const POST = withAuth<
       updatedAt: false,
     },
     with: {
-      _category: {
+      category: {
         columns: {
           userId: false,
           createdAt: false,

--- a/src/app/api/monzo/transactions/utils.ts
+++ b/src/app/api/monzo/transactions/utils.ts
@@ -32,7 +32,7 @@ export function getDatabaseTransaction(
     localCurrency: local_currency,
     accountId: account_id,
     merchantId: merchant ? merchant.id : null,
-    category: category || null,
+    monzo_category: category || null,
     categoryId: category || null,
   };
 }
@@ -47,7 +47,7 @@ export function getDatabaseMerchant(
     ...other,
     groupId: group_id,
     disableFeedback: disable_feedback,
-    category: category || null,
+    monzo_category: category || null,
     categoryId: category || null,
     accountId,
   };

--- a/src/lib/db/migrations/0006_rename_category_column_to_monzo_category.sql
+++ b/src/lib/db/migrations/0006_rename_category_column_to_monzo_category.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "monzo_merchants" RENAME COLUMN "category" TO "monzo_category";--> statement-breakpoint
+ALTER TABLE "monzo_transactions" RENAME COLUMN "category" TO "monzo_category";

--- a/src/lib/db/migrations/meta/0006_snapshot.json
+++ b/src/lib/db/migrations/meta/0006_snapshot.json
@@ -1,0 +1,744 @@
+{
+  "id": "262a4376-1fa3-4d97-8749-3c0dbabae32f",
+  "prevId": "83b720f9-8c2f-4bc6-83ff-0aa4d4379d54",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_ip": {
+          "name": "client_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "user_user_id_unique": {
+          "name": "user_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.monzo_accounts": {
+      "name": "monzo_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_type": {
+          "name": "owner_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_flex": {
+          "name": "is_flex",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_type": {
+          "name": "product_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owners": {
+          "name": "owners",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_number": {
+          "name": "account_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_code": {
+          "name": "sort_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "monzo_accounts_user_id_user_id_fk": {
+          "name": "monzo_accounts_user_id_user_id_fk",
+          "tableFrom": "monzo_accounts",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.monzo_categories": {
+      "name": "monzo_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_monzo": {
+          "name": "is_monzo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "monzo_categories_user_id_user_id_fk": {
+          "name": "monzo_categories_user_id_user_id_fk",
+          "tableFrom": "monzo_categories",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.monzo_merchants": {
+      "name": "monzo_merchants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monzo_category": {
+          "name": "monzo_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "online": {
+          "name": "online",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "atm": {
+          "name": "atm",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disable_feedback": {
+          "name": "disable_feedback",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "monzo_merchants_category_id_monzo_categories_id_fk": {
+          "name": "monzo_merchants_category_id_monzo_categories_id_fk",
+          "tableFrom": "monzo_merchants",
+          "tableTo": "monzo_categories",
+          "columnsFrom": ["category_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "monzo_merchants_account_id_monzo_accounts_id_fk": {
+          "name": "monzo_merchants_account_id_monzo_accounts_id_fk",
+          "tableFrom": "monzo_merchants",
+          "tableTo": "monzo_accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.monzo_transactions": {
+      "name": "monzo_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monzo_category": {
+          "name": "monzo_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settled": {
+          "name": "settled",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_amount": {
+          "name": "local_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_currency": {
+          "name": "local_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "merchant_id": {
+          "name": "merchant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "monzo_transactions_category_id_monzo_categories_id_fk": {
+          "name": "monzo_transactions_category_id_monzo_categories_id_fk",
+          "tableFrom": "monzo_transactions",
+          "tableTo": "monzo_categories",
+          "columnsFrom": ["category_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "monzo_transactions_account_id_monzo_accounts_id_fk": {
+          "name": "monzo_transactions_account_id_monzo_accounts_id_fk",
+          "tableFrom": "monzo_transactions",
+          "tableTo": "monzo_accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "monzo_transactions_merchant_id_monzo_merchants_id_fk": {
+          "name": "monzo_transactions_merchant_id_monzo_merchants_id_fk",
+          "tableFrom": "monzo_transactions",
+          "tableTo": "monzo_merchants",
+          "columnsFrom": ["merchant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/lib/db/migrations/meta/_journal.json
+++ b/src/lib/db/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1750447791551,
       "tag": "0005_dissociated_monzo_category_from_categories_table",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1750964426643,
+      "tag": "0006_rename_category_column_to_monzo_category",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/db/schema/monzo-schema.ts
+++ b/src/lib/db/schema/monzo-schema.ts
@@ -62,8 +62,7 @@ export const monzoMerchants = pgTable("monzo_merchants", {
   logo: text("logo").notNull(),
   emoji: text("emoji"),
   categoryId: text("category_id").references(() => monzoCategories.id),
-  // TODO: rename category -> monzo_category
-  category: text("category"),
+  monzo_category: text("monzo_category"),
   online: boolean("online").notNull(),
   atm: boolean("atm").notNull(),
   address: jsonb("address").notNull(),
@@ -84,8 +83,7 @@ export const monzoMerchants = pgTable("monzo_merchants", {
 export const monzoMerchantsRelations = relations(
   monzoMerchants,
   ({ one, many }) => ({
-    // TODO: rename _category -> category oncce category has been renamed to monzo_category
-    _category: one(monzoCategories, {
+    category: one(monzoCategories, {
       fields: [monzoMerchants.categoryId],
       references: [monzoCategories.id],
     }),
@@ -102,8 +100,7 @@ export const monzoTransactions = pgTable("monzo_transactions", {
   // TODO: fees field is missing
   notes: text("notes"),
   categoryId: text("category_id").references(() => monzoCategories.id),
-  // TODO: rename category -> monzo_category
-  category: text("category"),
+  monzo_category: text("monzo_category"),
   settled: timestamp("settled"),
   localAmount: numeric("local_amount").notNull(),
   localCurrency: text("local_currency").notNull(),
@@ -122,8 +119,7 @@ export const monzoTransactions = pgTable("monzo_transactions", {
 export const monzoTransactionsRelations = relations(
   monzoTransactions,
   ({ one }) => ({
-    // TODO: rename _category -> category oncce category has been renamed to monzo_category
-    _category: one(monzoCategories, {
+    category: one(monzoCategories, {
       fields: [monzoTransactions.categoryId],
       references: [monzoCategories.id],
     }),

--- a/src/lib/types/merchant.ts
+++ b/src/lib/types/merchant.ts
@@ -20,10 +20,10 @@ export type Merchant = {
   name: string;
   logo: string;
   emoji: string | null;
-  category: string | null;
+  monzo_category: string | null;
   online: boolean;
   atm: boolean;
   address: MerchantAddress;
   metadata: Record<string, string>;
-  _category?: Pick<Category, "id" | "name" | "isMonzo"> | null;
+  category?: Pick<Category, "id" | "name" | "isMonzo"> | null;
 };

--- a/src/lib/types/transaction.ts
+++ b/src/lib/types/transaction.ts
@@ -8,12 +8,12 @@ export type Transaction = {
   amount: number;
   currency: string;
   notes: string | null;
-  category: string | null;
+  monzo_category: string | null;
   settled: string | null;
   localAmount: number;
   localCurrency: string;
   merchantId: string | null;
   categoryId: string | null;
   merchant?: Pick<Merchant, "id" | "groupId" | "name" | "logo"> | null;
-  _category?: Pick<Category, "id" | "name" | "isMonzo"> | null;
+  category?: Pick<Category, "id" | "name" | "isMonzo"> | null;
 };


### PR DESCRIPTION
This PR renames the `category` column to `monzo_category` in the `merchants` and `transactions` table, for clear distinction between internal category and the default imported category. Also, it allows us to use `category` field name as a Drizzle relation :)