### PR TITLE
refactor/db/split-merchant-groups-to-separate-table

### DIFF
--- a/src/app/api/categories/[id]/merchants/route.ts
+++ b/src/app/api/categories/[id]/merchants/route.ts
@@ -3,18 +3,17 @@ import { and, desc, eq } from "drizzle-orm";
 import { withAccount } from "@/lib/api/middleware";
 import { MiddlewareResponse } from "@/lib/api/response";
 import { db } from "@/lib/db";
-import { monzoMerchants } from "@/lib/db/schema/monzo-schema";
-import type { Merchant } from "@/lib/types/merchant";
+import { monzoMerchantGroups } from "@/lib/db/schema/monzo-schema";
+import type { MerchantGroup } from "@/lib/types/merchant";
 
 export const GET = withAccount<
-  Merchant[],
+  MerchantGroup[],
   { params: Promise<{ id: string }> }
 >(async ({ context: { params }, accountId }) => {
   const { id: categoryId } = await params;
 
-  const dbMerchants = await db.query.monzoMerchants.findMany({
+  const dbMerchantGroups = await db.query.monzoMerchantGroups.findMany({
     columns: {
-      disableFeedback: false,
       accountId: false,
       createdAt: false,
       updatedAt: false,
@@ -27,21 +26,20 @@ export const GET = withAccount<
           updatedAt: false,
         },
       },
+      merchants: {
+        columns: {
+          accountId: false,
+          createdAt: false,
+          updatedAt: false,
+        },
+      },
     },
     where: and(
-      eq(monzoMerchants.categoryId, categoryId),
-      eq(monzoMerchants.accountId, accountId)
+      eq(monzoMerchantGroups.categoryId, categoryId),
+      eq(monzoMerchantGroups.accountId, accountId)
     ),
-    orderBy: desc(monzoMerchants.name),
+    orderBy: desc(monzoMerchantGroups.name),
   });
 
-  const merchants: Merchant[] = dbMerchants.map((dbMerchant) => {
-    return {
-      ...dbMerchant,
-      address: dbMerchant.address as Merchant["address"],
-      metadata: dbMerchant.metadata as Merchant["metadata"],
-    };
-  });
-
-  return MiddlewareResponse.success(merchants);
+  return MiddlewareResponse.success(dbMerchantGroups);
 });

--- a/src/app/api/categories/[id]/transactions/route.ts
+++ b/src/app/api/categories/[id]/transactions/route.ts
@@ -30,9 +30,18 @@ export const GET = withAccount<
         columns: {
           id: true,
           groupId: true,
-          emoji: true,
-          name: true,
-          logo: true,
+          address: true,
+          online: true,
+        },
+        with: {
+          group: {
+            columns: {
+              id: true,
+              name: true,
+              logo: true,
+              emoji: true,
+            },
+          },
         },
       },
     },

--- a/src/lib/db/migrations/0009_add_merchant_groups_table.sql
+++ b/src/lib/db/migrations/0009_add_merchant_groups_table.sql
@@ -1,0 +1,28 @@
+CREATE TABLE "monzo_merchant_groups" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"logo" text NOT NULL,
+	"emoji" text,
+	"disable_feedback" boolean NOT NULL,
+	"atm" boolean NOT NULL,
+	"metadata" jsonb NOT NULL,
+	"monzo_category" text,
+	"category_id" text,
+	"account_id" text NOT NULL,
+	"created_at" timestamp NOT NULL,
+	"updated_at" timestamp NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "monzo_merchants" DROP CONSTRAINT "monzo_merchants_category_id_monzo_categories_id_fk";
+--> statement-breakpoint
+ALTER TABLE "monzo_merchant_groups" ADD CONSTRAINT "monzo_merchant_groups_category_id_monzo_categories_id_fk" FOREIGN KEY ("category_id") REFERENCES "public"."monzo_categories"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "monzo_merchant_groups" ADD CONSTRAINT "monzo_merchant_groups_account_id_monzo_accounts_id_fk" FOREIGN KEY ("account_id") REFERENCES "public"."monzo_accounts"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "monzo_merchants" ADD CONSTRAINT "monzo_merchants_group_id_monzo_merchant_groups_id_fk" FOREIGN KEY ("group_id") REFERENCES "public"."monzo_merchant_groups"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "monzo_merchants" DROP COLUMN "name";--> statement-breakpoint
+ALTER TABLE "monzo_merchants" DROP COLUMN "logo";--> statement-breakpoint
+ALTER TABLE "monzo_merchants" DROP COLUMN "emoji";--> statement-breakpoint
+ALTER TABLE "monzo_merchants" DROP COLUMN "category_id";--> statement-breakpoint
+ALTER TABLE "monzo_merchants" DROP COLUMN "monzo_category";--> statement-breakpoint
+ALTER TABLE "monzo_merchants" DROP COLUMN "atm";--> statement-breakpoint
+ALTER TABLE "monzo_merchants" DROP COLUMN "disable_feedback";--> statement-breakpoint
+ALTER TABLE "monzo_merchants" DROP COLUMN "metadata";

--- a/src/lib/db/migrations/meta/0009_snapshot.json
+++ b/src/lib/db/migrations/meta/0009_snapshot.json
@@ -1,0 +1,806 @@
+{
+  "id": "e2d18ba2-19d6-4be7-b1d2-442157b5b8c2",
+  "prevId": "c38729f2-0df7-443f-b735-c222f176a000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_ip": {
+          "name": "client_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "user_user_id_unique": {
+          "name": "user_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.monzo_accounts": {
+      "name": "monzo_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_type": {
+          "name": "owner_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_flex": {
+          "name": "is_flex",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_type": {
+          "name": "product_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owners": {
+          "name": "owners",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_number": {
+          "name": "account_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_code": {
+          "name": "sort_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "monzo_accounts_user_id_user_id_fk": {
+          "name": "monzo_accounts_user_id_user_id_fk",
+          "tableFrom": "monzo_accounts",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.monzo_categories": {
+      "name": "monzo_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_monzo": {
+          "name": "is_monzo",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "monzo_categories_account_id_monzo_accounts_id_fk": {
+          "name": "monzo_categories_account_id_monzo_accounts_id_fk",
+          "tableFrom": "monzo_categories",
+          "tableTo": "monzo_accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.monzo_merchant_groups": {
+      "name": "monzo_merchant_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disable_feedback": {
+          "name": "disable_feedback",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "atm": {
+          "name": "atm",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "monzo_category": {
+          "name": "monzo_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "monzo_merchant_groups_category_id_monzo_categories_id_fk": {
+          "name": "monzo_merchant_groups_category_id_monzo_categories_id_fk",
+          "tableFrom": "monzo_merchant_groups",
+          "tableTo": "monzo_categories",
+          "columnsFrom": ["category_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "monzo_merchant_groups_account_id_monzo_accounts_id_fk": {
+          "name": "monzo_merchant_groups_account_id_monzo_accounts_id_fk",
+          "tableFrom": "monzo_merchant_groups",
+          "tableTo": "monzo_accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.monzo_merchants": {
+      "name": "monzo_merchants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "online": {
+          "name": "online",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "monzo_merchants_group_id_monzo_merchant_groups_id_fk": {
+          "name": "monzo_merchants_group_id_monzo_merchant_groups_id_fk",
+          "tableFrom": "monzo_merchants",
+          "tableTo": "monzo_merchant_groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "monzo_merchants_account_id_monzo_accounts_id_fk": {
+          "name": "monzo_merchants_account_id_monzo_accounts_id_fk",
+          "tableFrom": "monzo_merchants",
+          "tableTo": "monzo_accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.monzo_transactions": {
+      "name": "monzo_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owners": {
+          "name": "owners",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "monzo_category": {
+          "name": "monzo_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settled": {
+          "name": "settled",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "local_amount": {
+          "name": "local_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "local_currency": {
+          "name": "local_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merchant_id": {
+          "name": "merchant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "monzo_transactions_account_id_monzo_accounts_id_fk": {
+          "name": "monzo_transactions_account_id_monzo_accounts_id_fk",
+          "tableFrom": "monzo_transactions",
+          "tableTo": "monzo_accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "monzo_transactions_category_id_monzo_categories_id_fk": {
+          "name": "monzo_transactions_category_id_monzo_categories_id_fk",
+          "tableFrom": "monzo_transactions",
+          "tableTo": "monzo_categories",
+          "columnsFrom": ["category_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "monzo_transactions_merchant_id_monzo_merchants_id_fk": {
+          "name": "monzo_transactions_merchant_id_monzo_merchants_id_fk",
+          "tableFrom": "monzo_transactions",
+          "tableTo": "monzo_merchants",
+          "columnsFrom": ["merchant_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/lib/db/migrations/meta/_journal.json
+++ b/src/lib/db/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1751107270825,
       "tag": "0008_add_fees_column_to_monzo_transactions",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1751317544514,
+      "tag": "0009_add_merchant_groups_table",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/db/schema/monzo-schema.ts
+++ b/src/lib/db/schema/monzo-schema.ts
@@ -57,17 +57,11 @@ export const monzoAccounts = pgTable("monzo_accounts", {
 
 export const monzoMerchants = pgTable("monzo_merchants", {
   id: text("id").primaryKey(),
-  groupId: text("group_id").notNull(),
-  name: text("name").notNull(),
-  logo: text("logo").notNull(),
-  emoji: text("emoji"),
-  monzo_category: text("monzo_category"),
-  online: boolean("online").notNull(),
-  atm: boolean("atm").notNull(),
+  groupId: text("group_id")
+    .notNull()
+    .references(() => monzoMerchantGroups.id, { onDelete: "cascade" }),
   address: jsonb("address").notNull(),
-  disableFeedback: boolean("disable_feedback").notNull(),
-  metadata: jsonb("metadata").notNull(),
-  categoryId: text("category_id").references(() => monzoCategories.id),
+  online: boolean("online").notNull(),
   accountId: text("account_id")
     .notNull()
     .references(() => monzoAccounts.id, { onDelete: "cascade" }),
@@ -82,11 +76,43 @@ export const monzoMerchants = pgTable("monzo_merchants", {
 export const monzoMerchantsRelations = relations(
   monzoMerchants,
   ({ one, many }) => ({
-    category: one(monzoCategories, {
-      fields: [monzoMerchants.categoryId],
-      references: [monzoCategories.id],
+    group: one(monzoMerchantGroups, {
+      fields: [monzoMerchants.groupId],
+      references: [monzoMerchantGroups.id],
     }),
     transactions: many(monzoTransactions),
+  })
+);
+
+export const monzoMerchantGroups = pgTable("monzo_merchant_groups", {
+  id: text("id").primaryKey(),
+  name: text("name").notNull(),
+  logo: text("logo").notNull(),
+  emoji: text("emoji"),
+  disableFeedback: boolean("disable_feedback").notNull(),
+  atm: boolean("atm").notNull(),
+  metadata: jsonb("metadata").notNull(),
+  monzo_category: text("monzo_category"),
+  categoryId: text("category_id").references(() => monzoCategories.id),
+  accountId: text("account_id")
+    .notNull()
+    .references(() => monzoAccounts.id, { onDelete: "cascade" }),
+  createdAt: timestamp("created_at")
+    .$defaultFn(() => new Date())
+    .notNull(),
+  updatedAt: timestamp("updated_at")
+    .$defaultFn(() => new Date())
+    .notNull(),
+});
+
+export const monzoMerchantGroupsRelations = relations(
+  monzoMerchantGroups,
+  ({ many, one }) => ({
+    merchants: many(monzoMerchants),
+    category: one(monzoCategories, {
+      fields: [monzoMerchantGroups.categoryId],
+      references: [monzoCategories.id],
+    }),
   })
 );
 

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -1,6 +1,7 @@
 import type {
   monzoAccounts,
   monzoCategories,
+  monzoMerchantGroups,
   monzoMerchants,
   monzoTransactions,
 } from "./schema";
@@ -8,4 +9,5 @@ import type {
 export type MonzoDbAccount = typeof monzoAccounts.$inferInsert;
 export type MonzoDbTransaction = typeof monzoTransactions.$inferInsert;
 export type MonzoDbMerchant = typeof monzoMerchants.$inferInsert;
+export type MonzoDbMerchantGroup = typeof monzoMerchantGroups.$inferInsert;
 export type MonzoDbCategory = typeof monzoCategories.$inferInsert;

--- a/src/lib/types/merchant.ts
+++ b/src/lib/types/merchant.ts
@@ -14,16 +14,23 @@ type MerchantAddress = {
   postcode: string;
 };
 
-export type Merchant = {
+export type MerchantGroup = {
   id: string;
-  groupId: string;
   name: string;
   logo: string;
   emoji: string | null;
-  monzo_category: string | null;
-  online: boolean;
+  disableFeedback: boolean;
   atm: boolean;
-  address: MerchantAddress;
-  metadata: Record<string, string>;
+  monzo_category: string | null;
+  categoryId: string | null;
   category?: Pick<Category, "id" | "name" | "isMonzo"> | null;
+  merchant?: Merchant[];
+};
+
+export type Merchant = {
+  id: string;
+  groupId: string;
+  online: boolean;
+  address: MerchantAddress;
+  group?: MerchantGroup;
 };

--- a/src/lib/types/transaction.ts
+++ b/src/lib/types/transaction.ts
@@ -1,5 +1,5 @@
 import type { Category } from "./category";
-import type { Merchant } from "./merchant";
+import type { Merchant, MerchantGroup } from "./merchant";
 
 export type Transaction = {
   id: string;
@@ -15,6 +15,10 @@ export type Transaction = {
   localCurrency: string;
   merchantId: string | null;
   categoryId: string | null;
-  merchant?: Pick<Merchant, "id" | "groupId" | "name" | "logo"> | null;
+  merchant?:
+    | (Pick<Merchant, "id" | "groupId"> & {
+        group: Pick<MerchantGroup, "id" | "name" | "logo" | "emoji">;
+      })
+    | null;
   category?: Pick<Category, "id" | "name" | "isMonzo"> | null;
 };


### PR DESCRIPTION
This PR splits the merchant groups away from the `monzo_merchants` table and into a separate table `monzo_merchant_groups`

🎯 Main changes:
- Added new `monzo_merchant_groups` table with `id` (group ID), `name`, `logo`, `emoji`, `disableFeedback`, `atm`, `metadata`, `monzo_category`, `categoryId`, `accountId`
- `monzo_merchants` now only stores `id` (merchant ID), `groupId` (Foreign key to `monzo_merchant_groups`), `address`, `online`, `accountId`
- The data is separated in `api/monzo/transactions` (seed) endpoint (in `getDatabaseTable`)
- `/api/categories/:id/merchants` now uses `monzo_merchants_groups` table but remains unchanged from an user perspective
- Similarly `/api/categories/:id/transactions` now uses deeply nested relations to get the merchant group data (like name/logo) 