### PR TITLE
feat/api/transactions-category-update

### DIFF
--- a/src/app/(pages)/transactions/[id]/page.tsx
+++ b/src/app/(pages)/transactions/[id]/page.tsx
@@ -1,0 +1,107 @@
+"use server";
+
+import type { JSX } from "react";
+import { headers } from "next/headers";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+
+import type { Category } from "@/lib/types";
+
+async function updateTransactionCategory(
+  id: string,
+  formData: FormData
+): Promise<void> {
+  "use server";
+
+  const categoryId = formData.get("categoryId");
+  if (!categoryId || typeof categoryId !== "string") {
+    throw new Error("Category is required");
+  }
+
+  const headersList = await headers();
+  const cookie = headersList.get("cookie");
+
+  const response = await fetch(
+    `http://localhost:3001/api/transactions/${id}`,
+    {
+      method: "PUT",
+      headers: {
+        ...(cookie ? { cookie } : {}),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ categoryId }),
+    }
+  );
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(error);
+  }
+
+  redirect(`/transactions/${id}`);
+}
+
+async function TransactionPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<JSX.Element> {
+  const { id } = await params;
+
+  // Fetch transaction
+  const transactionRes = await fetch(
+    `http://localhost:3001/api/transactions/${id}`,
+    { headers: await headers() }
+  );
+  if (!transactionRes.ok) {
+    const error = await transactionRes.text();
+    throw new Error(JSON.stringify(error, null, 2));
+  }
+  const { data: transaction } = await transactionRes.json();
+
+  // Fetch categories
+  const categoriesRes = await fetch(
+    `http://localhost:3001/api/categories`,
+    { headers: await headers() }
+  );
+  if (!categoriesRes.ok) {
+    const error = await categoriesRes.text();
+    throw new Error(JSON.stringify(error, null, 2));
+  }
+  const { data: categories } = (await categoriesRes.json()) as {
+    data: Category[];
+  };
+
+  const updateCategoryWithId = updateTransactionCategory.bind(null, id);
+
+  return (
+    <div>
+      <pre>{JSON.stringify(transaction, null, 2)}</pre>
+      <h1>Edit Transaction Category</h1>
+      <form action={updateCategoryWithId}>
+        <div>
+          <label htmlFor="categoryId">Category</label>
+          <select
+            id="categoryId"
+            name="categoryId"
+            required
+            defaultValue={transaction.category?.id || ""}
+          >
+            <option value="" disabled>
+              Select a category
+            </option>
+            {categories.map((cat) => (
+              <option key={cat.id} value={cat.id}>
+                {cat.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <button type="submit">Update</button>
+      </form>
+      <Link href="/transactions">Back to Transactions</Link>
+    </div>
+  );
+}
+
+export default TransactionPage;

--- a/src/app/(pages)/transactions/page.tsx
+++ b/src/app/(pages)/transactions/page.tsx
@@ -204,7 +204,11 @@ function TransactionsPage(): JSX.Element {
         <tbody>
           {transactions?.data?.map((tx) => (
             <tr key={tx.id}>
-              <td>{tx.description}</td>
+              <td>
+                <Link href={`/transactions/${tx.id}`}>
+                  {tx.description}
+                </Link>
+              </td>
               <td>{tx.amount / 100}</td>
               <td>{tx.created}</td>
               <td>{tx.settled}</td>

--- a/src/app/api/transactions/[id]/route.ts
+++ b/src/app/api/transactions/[id]/route.ts
@@ -1,0 +1,140 @@
+import { and, eq } from "drizzle-orm";
+
+import { withAccount } from "@/lib/api/middleware";
+import { MiddlewareResponse } from "@/lib/api/response";
+import {
+  db,
+  monzoCategories,
+  monzoMerchantGroups,
+  monzoMerchants,
+  monzoTransactions,
+} from "@/lib/db";
+import type { MerchantAddress, Transaction } from "@/lib/types";
+
+export const GET = withAccount<
+  Transaction,
+  { params: Promise<{ id: string }> }
+>(async ({ context: { params }, accountId }) => {
+  const { id: transactionId } = await params;
+
+  const dbTransaction = await db
+    .select()
+    .from(monzoTransactions)
+    .leftJoin(
+      monzoCategories,
+      eq(monzoTransactions.categoryId, monzoCategories.id)
+    )
+    .leftJoin(
+      monzoMerchants,
+      eq(monzoTransactions.merchantId, monzoMerchants.id)
+    )
+    .leftJoin(
+      monzoMerchantGroups,
+      eq(monzoTransactions.merchantGroupId, monzoMerchantGroups.id)
+    )
+    .where(
+      and(
+        eq(monzoTransactions.id, transactionId),
+        eq(monzoTransactions.accountId, accountId)
+      )
+    )
+    .limit(1);
+
+  if (!dbTransaction || dbTransaction.length === 0) {
+    return MiddlewareResponse.notFound("Transaction not found");
+  }
+
+  const {
+    monzo_transactions,
+    monzo_categories,
+    monzo_merchants,
+    monzo_merchant_groups,
+  } = dbTransaction[0];
+
+  const transaction: Transaction = {
+    ...monzo_transactions,
+    created:
+      monzo_transactions.created instanceof Date
+        ? monzo_transactions.created.toISOString()
+        : monzo_transactions.created,
+    settled:
+      monzo_transactions.settled instanceof Date
+        ? monzo_transactions.settled.toISOString()
+        : monzo_transactions.settled,
+    fees: monzo_transactions.fees as Record<string, unknown>,
+    amount: Number(monzo_transactions.amount),
+    localAmount: Number(monzo_transactions.localAmount),
+    merchant: monzo_merchants
+      ? {
+          id: monzo_merchants.id,
+          groupId: monzo_merchants.groupId,
+          online: monzo_merchants.online,
+          address: monzo_merchants.address as MerchantAddress,
+        }
+      : null,
+    category: monzo_categories
+      ? {
+          id: monzo_categories.id,
+          name: monzo_categories.name,
+          isMonzo: monzo_categories.isMonzo,
+        }
+      : null,
+    merchantGroup: monzo_merchant_groups
+      ? {
+          id: monzo_merchant_groups.id,
+          name: monzo_merchant_groups.name,
+          logo: monzo_merchant_groups.logo,
+          emoji: monzo_merchant_groups.emoji,
+        }
+      : null,
+  };
+
+  return MiddlewareResponse.success(transaction);
+});
+
+export const PUT = withAccount<
+  Transaction,
+  { params: Promise<{ id: string }> }
+>(async ({ request, context: { params }, accountId: _accountId }) => {
+  const { id: transactionId } = await params;
+
+  const body = await request.json();
+  const { categoryId } = body;
+
+  if (!categoryId) {
+    return MiddlewareResponse.badRequest("Category ID is required");
+  }
+
+  const [dbTransaction] = await db
+    .update(monzoTransactions)
+    .set({ categoryId })
+    .where(eq(monzoTransactions.id, transactionId))
+    .returning();
+
+  if (!dbTransaction) {
+    return MiddlewareResponse.notFound("Transaction not found");
+  }
+
+  const {
+    createdAt: _createdAt,
+    updatedAt: _updatedAt,
+    ...rest
+  } = dbTransaction;
+
+  const transaction: Transaction = {
+    ...rest,
+    created:
+      dbTransaction.created instanceof Date
+        ? dbTransaction.created.toISOString()
+        : dbTransaction.created,
+    settled:
+      dbTransaction.settled instanceof Date
+        ? dbTransaction.settled.toISOString()
+        : null,
+    amount: Number(dbTransaction.amount),
+    localAmount: Number(dbTransaction.localAmount),
+    fees: dbTransaction.fees as Record<string, unknown>,
+  };
+
+  return MiddlewareResponse.success(transaction);
+});


### PR DESCRIPTION
The purpose of this PR is to add the functionality to update the category of a single transaction

🎯 **Main changes:**
- Added GET `/api/transactions/:id` endpoint to fetch a single transaction
- Added PUT `/api/transactions/:id` endpoint that allows users to update the category of a single transactions
- Added new basic `/transactions/:id` page to allow users to edit the category of a single transaction

📸 **Preview:**

https://github.com/user-attachments/assets/c3faba74-b9b8-48e7-83fc-d661275ae504
